### PR TITLE
[ FEATURE ] Readme Alias Port to Docker Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ An Application to
 
 ## Installation
 
+First we need to create an alias for the local port 127.0.0.1 to use in the mongo replicas with the Docker images:
+
+```bash
+# Open hosts file to edit
+$ sudo nano /etc/hosts
+```
+
+Edit file:
+
+```txt
+  //...
+  # docker network
+  127.0.0.1      mongo1 mongo2 mongo3
+```
+
 On the first use of application, we need create the docker container. Run the following:
 
 ```bash


### PR DESCRIPTION
# Feature Request

## Objective

- Add Instruction to Alias Port to Docker Images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentação**
	- Atualizadas as instruções de instalação para incluir um novo passo sobre a criação de um alias para o porto local `127.0.0.1`, facilitando o uso de réplicas do MongoDB com imagens Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->